### PR TITLE
Protect NullPointerException on MediaSessionCompat

### DIFF
--- a/android/src/main/java/com/ingageco/capacitormusiccontrols/CapacitorMusicControls.java
+++ b/android/src/main/java/com/ingageco/capacitormusiccontrols/CapacitorMusicControls.java
@@ -302,17 +302,21 @@ public class CapacitorMusicControls extends Plugin {
 
 	// Register pendingIntent for broacast
 	public void registerMediaButtonEvent(){
-
-		this.mediaSessionCompat.setMediaButtonReceiver(this.mediaButtonPendingIntent);
-
+		if (this.mediaSessionCompat != null) {
+			this.mediaSessionCompat.setMediaButtonReceiver(this.mediaButtonPendingIntent);
+		}
 	}
 
 	public void unregisterMediaButtonEvent(){
-		this.mediaSessionCompat.setMediaButtonReceiver(null);
+		if (this.mediaSessionCompat != null) {
+			this.mediaSessionCompat.setMediaButtonReceiver(null);
+		}
 	}
 
 	public void destroyPlayerNotification(){
-		this.notification.destroy();
+		if (this.notification) {
+			this.notification.destroy();
+		}
 	}
 
 

--- a/android/src/main/java/com/ingageco/capacitormusiccontrols/CapacitorMusicControls.java
+++ b/android/src/main/java/com/ingageco/capacitormusiccontrols/CapacitorMusicControls.java
@@ -314,7 +314,7 @@ public class CapacitorMusicControls extends Plugin {
 	}
 
 	public void destroyPlayerNotification(){
-		if (this.notification) {
+		if (this.notification != null) {
 			this.notification.destroy();
 		}
 	}


### PR DESCRIPTION
I had an issue when playing an audio file, where the event 'music-controls-headset-unplugged' was triggered right away and a NullPointerException occured, because this.mediaSessionCompat was null.