### PR TITLE
removed notification badge from android

### DIFF
--- a/android/src/main/java/com/ingageco/capacitormusiccontrols/MusicControlsNotification.java
+++ b/android/src/main/java/com/ingageco/capacitormusiccontrols/MusicControlsNotification.java
@@ -62,6 +62,7 @@ public class MusicControlsNotification {
 
 			// Configure the notification channel.
 			mChannel.setDescription(description);
+			mChannel.setShowBadge(false);
 
 			this.notificationManager.createNotificationChannel(mChannel);
     }


### PR DESCRIPTION
Suggest getting rid of the notification badge for music controls, as it makes little sense in most use cases.